### PR TITLE
Enable USB CDC on boot

### DIFF
--- a/board_definitions/motorgo_1.0/boards.txt
+++ b/board_definitions/motorgo_1.0/boards.txt
@@ -49,7 +49,7 @@ motorgomini_v1_r1.build.variant=motorgomini_v1_r1
 motorgomini_v1_r1.build.board=MOTORGOMINI_V1_R1
 
 motorgomini_v1_r1.build.usb_mode=1
-motorgomini_v1_r1.build.cdc_on_boot=0
+motorgomini_v1_r1.build.cdc_on_boot=1
 motorgomini_v1_r1.build.msc_on_boot=0
 motorgomini_v1_r1.build.dfu_on_boot=0
 motorgomini_v1_r1.build.f_cpu=240000000L
@@ -135,9 +135,9 @@ motorgomini_v1_r1.menu.USBMode.hwcdc.build.usb_mode=1
 motorgomini_v1_r1.menu.USBMode.default=USB-OTG (TinyUSB)
 motorgomini_v1_r1.menu.USBMode.default.build.usb_mode=0
 
-motorgomini_v1_r1.menu.CDCOnBoot.default=Disabled
-motorgomini_v1_r1.menu.CDCOnBoot.default.build.cdc_on_boot=0
-motorgomini_v1_r1.menu.CDCOnBoot.cdc=Enabled
+motorgomini_v1_r1.menu.CDCOnBoot.default=Enabled
+motorgomini_v1_r1.menu.CDCOnBoot.default.build.cdc_on_boot=1
+motorgomini_v1_r1.menu.CDCOnBoot.cdc=Disabled
 motorgomini_v1_r1.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
 
 motorgomini_v1_r1.menu.MSCOnBoot.default=Disabled
@@ -276,7 +276,7 @@ motorgomini_v1_r2.build.variant=motorgomini_v1_r2
 motorgomini_v1_r2.build.board=MOTORGOMINI_V1_R2
 
 motorgomini_v1_r2.build.usb_mode=1
-motorgomini_v1_r2.build.cdc_on_boot=0
+motorgomini_v1_r2.build.cdc_on_boot=1
 motorgomini_v1_r2.build.msc_on_boot=0
 motorgomini_v1_r2.build.dfu_on_boot=0
 motorgomini_v1_r2.build.f_cpu=240000000L
@@ -362,9 +362,9 @@ motorgomini_v1_r2.menu.USBMode.hwcdc.build.usb_mode=1
 motorgomini_v1_r2.menu.USBMode.default=USB-OTG (TinyUSB)
 motorgomini_v1_r2.menu.USBMode.default.build.usb_mode=0
 
-motorgomini_v1_r2.menu.CDCOnBoot.default=Disabled
-motorgomini_v1_r2.menu.CDCOnBoot.default.build.cdc_on_boot=0
-motorgomini_v1_r2.menu.CDCOnBoot.cdc=Enabled
+motorgomini_v1_r2.menu.CDCOnBoot.default=Enabled
+motorgomini_v1_r2.menu.CDCOnBoot.default.build.cdc_on_boot=1
+motorgomini_v1_r2.menu.CDCOnBoot.cdc=Disabled
 motorgomini_v1_r2.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
 
 motorgomini_v1_r2.menu.MSCOnBoot.default=Disabled
@@ -501,7 +501,7 @@ motorgomini_v2_r1.build.variant=motorgomini_v2_r1
 motorgomini_v2_r1.build.board=MOTORGOMINI_V2_R1
 
 motorgomini_v2_r1.build.usb_mode=1
-motorgomini_v2_r1.build.cdc_on_boot=0
+motorgomini_v2_r1.build.cdc_on_boot=1
 motorgomini_v2_r1.build.msc_on_boot=0
 motorgomini_v2_r1.build.dfu_on_boot=0
 motorgomini_v2_r1.build.f_cpu=240000000L
@@ -587,9 +587,9 @@ motorgomini_v2_r1.menu.USBMode.hwcdc.build.usb_mode=1
 motorgomini_v2_r1.menu.USBMode.default=USB-OTG (TinyUSB)
 motorgomini_v2_r1.menu.USBMode.default.build.usb_mode=0
 
-motorgomini_v2_r1.menu.CDCOnBoot.default=Disabled
-motorgomini_v2_r1.menu.CDCOnBoot.default.build.cdc_on_boot=0
-motorgomini_v2_r1.menu.CDCOnBoot.cdc=Enabled
+motorgomini_v2_r1.menu.CDCOnBoot.default=Enabled
+motorgomini_v2_r1.menu.CDCOnBoot.default.build.cdc_on_boot=1
+motorgomini_v2_r1.menu.CDCOnBoot.cdc=Disabled
 motorgomini_v2_r1.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
 
 motorgomini_v2_r1.menu.MSCOnBoot.default=Disabled

--- a/board_definitions/package_motorgo_index.json
+++ b/board_definitions/package_motorgo_index.json
@@ -11,7 +11,7 @@
                     "architecture": "esp32",
                     "version": "1.0",
                     "category": "Contributed",
-                    "url": "https://github.com/Every-Flavor-Robotics/motorgo-arduino/raw/main/board_definitions/motorgo_1.0.zip",
+                    "url": "https://github.com/Every-Flavor-Robotics/motorgo-arduino/raw/bug-1/enable-usb-cdc/board_definitions/motorgo_1.0.zip",
                     "archiveFileName": "motorgo_1.0.zip",
                     "checksum": "SHA-256:eff55e09e861e3576fee7d7e445efe385d5c7931ae8975635aef9c830bf3c2be",
                     "size": "79735033",

--- a/board_definitions/package_motorgo_index.json
+++ b/board_definitions/package_motorgo_index.json
@@ -13,8 +13,8 @@
                     "category": "Contributed",
                     "url": "https://github.com/Every-Flavor-Robotics/motorgo-arduino/raw/main/board_definitions/motorgo_1.0.zip",
                     "archiveFileName": "motorgo_1.0.zip",
-                    "checksum": "SHA-256:e85c2707bbed369713a8dc3df3e95bcbc74d059995b85fca0648a48789a056e8",
-                    "size": "79735031",
+                    "checksum": "SHA-256:eff55e09e861e3576fee7d7e445efe385d5c7931ae8975635aef9c830bf3c2be",
+                    "size": "79735033",
                     "boards": [
                         {
                             "name": "MotorGo Mini V1 Rev1"


### PR DESCRIPTION
Enable USB CDC on boot for the Arduino package. Without this, the serial output does not stream when programmed in Arduino